### PR TITLE
feat: 添加2分钟自动重试扫描设备功能

### DIFF
--- a/pages/index/index.wxml
+++ b/pages/index/index.wxml
@@ -55,6 +55,11 @@
       <view class="error-message" wx:if="{{errorMessage}}">
         <text>{{errorMessage}}</text>
       </view>
+      
+      <!-- 自动重试状态 -->
+      <view class="retry-status" wx:if="{{autoRetryTimer && retryCount > 0}}">
+        <text>自动重试中... {{retryCount}}/{{maxRetryCount}}</text>
+      </view>
     </view>
   </view>
 

--- a/pages/index/index.wxss
+++ b/pages/index/index.wxss
@@ -217,12 +217,36 @@
 .error-message {
   margin-top: 20rpx;
   padding: 20rpx;
-  background-color: #fff2e8;
-  border: 1rpx solid #ffbb96;
+  background-color: #fee;
+  border: 1rpx solid #fcc;
   border-radius: 8rpx;
-  color: #fa541c;
+  color: #c33;
   font-size: 28rpx;
   text-align: center;
+}
+
+.retry-status {
+  margin-top: 20rpx;
+  padding: 20rpx;
+  background-color: #e3f2fd;
+  border: 1rpx solid #90caf9;
+  border-radius: 8rpx;
+  color: #1976d2;
+  font-size: 28rpx;
+  text-align: center;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 
 /* 禁用状态样式 */


### PR DESCRIPTION
## 功能描述
实现了用户要求的功能：点击扫描设备后，在2分钟内自动重试扫描设备。

## 主要变更
- **pages/index/index.js**: 添加自动重试逻辑、定时器管理、重试计数
- **pages/index/index.wxml**: 添加重试状态显示
- **pages/index/index.wxss**: 添加重试状态的样式和动画效果

## 实现细节
- 2分钟内最多重试10次，每次间隔12秒
- 智能重试策略：找到设备后自动停止重试
- 优化用户体验：显示重试进度、提供状态反馈
- 内存管理：清理所有定时器，避免内存泄漏

## 测试建议
1. 关闭ESP32设备，点击扫描观察自动重试
2. 在重试过程中开启ESP32设备，验证是否能成功连接
3. 检查重试进度显示是否正常