### PR TITLE
feat: 添加芯片温度显示功能

### DIFF
--- a/pages/index/index.js
+++ b/pages/index/index.js
@@ -32,6 +32,7 @@ Page({
       autoStart: false,            // 自动启动标志
       uptime: 0,                   // 系统运行时间(秒)
       freeHeap: 0,                 // 空闲堆内存(字节)
+      chipTemperature: 0,          // 芯片温度(摄氏度)
       formattedUptime: '00:00:00', // 格式化的运行时间显示
       formattedFreeHeap: '0KB',    // 格式化的内存显示
       // systemControl字段已删除
@@ -563,6 +564,7 @@ Page({
       // 格式化显示数据
       const formattedStatusData = {
         ...statusData,
+        chipTemperature: Math.round(statusData.chipTemperature || 0),
         formattedUptime: this.formatUptime(statusData.uptime),
         formattedFreeHeap: this.formatMemory(statusData.freeHeap)
       }

--- a/pages/index/index.wxml
+++ b/pages/index/index.wxml
@@ -181,6 +181,11 @@
       </view>
       
       <view class="status-row">
+        <text class="status-label">芯片温度:</text>
+        <text class="status-value">{{systemStatus.chipTemperature}}°C</text>
+      </view>
+      
+      <view class="status-row">
         <text class="status-label">当前循环:</text>
         <text class="status-value">{{systemStatus.currentCycleCount}}次</text>
       </view>

--- a/utils/ble.js
+++ b/utils/ble.js
@@ -736,7 +736,8 @@ async function getSystemStatusOnce(deviceId) {
     cycleCount: statusData.cycleCount || 0,
     autoStart: statusData.autoStart || false,
     uptime: statusData.uptime || 0,
-    freeHeap: statusData.freeHeap || 0
+    freeHeap: statusData.freeHeap || 0,
+    chipTemperature: statusData.chipTemperature || 0
   }
   
   console.log('获取系统状态成功:', systemStatus)


### PR DESCRIPTION
## 功能描述
在系统状态区域添加芯片温度显示，支持从ESP32设备获取实时温度数据。

## 变更内容
- ✅ 在index.wxml中添加芯片温度显示行
- ✅ 在index.js中添加chipTemperature字段并优化整数显示
- ✅ 在utils/ble.js中更新BLE通信模块支持温度字段
- ✅ 温度值以整数形式显示，提升用户体验

## 显示效果
芯片温度现在会以整数形式（如32°C）显示在系统状态区域，位于当前循环信息上方。

## 测试验证
- 已通过BLE通信测试，温度数据正确获取
- 显示格式符合要求，整数显示无小数位